### PR TITLE
fix(`optparse_flag()`): Use `action = "store"`

### DIFF
--- a/R/optparse_helper.R
+++ b/R/optparse_helper.R
@@ -30,9 +30,11 @@ optparse_flag <- function(
 ) {
   return(list(
     opt_str = short,
-    action = "store_true",
+    type = "logical",
+    action = "store",
     help = help,
-    default = default
+    default = default,
+    metavar = "flag"
   ))
 }
 

--- a/tests/testthat/test-optparse-helpers.R
+++ b/tests/testthat/test-optparse-helpers.R
@@ -60,10 +60,7 @@ test_that("optparse everything", {
   )
   testthat::expect_error(
     optparse_parameters(a = optparse_flag(), args = list("--args")),
-    regexp = paste0(
-      "Error in getopt(spec = spec, opt = args) : ",
-      "long flag \"args\" is invalid"
-    ),
+    regexp = "long flag \"args\" is invalid",
     fixed = TRUE
   )
 


### PR DESCRIPTION
We are in the process of releasing an update to {optparse} to CRAN and CRAN's reverse dependency check found the following bug in this package:

* `optparse_flag()` was using `action = "store_true"` (which cannot take an argument) and then passing it an argument.  
* Previously this would result in an error if you passed an argument using an `=` i.e. `--a-boolean=FALSE` or if you used a short flag i.e. `-b FALSE` but due to an oversight didn't throw an ERROR if you used a long flag with a space i.e. `--a-boolean FALSE`.  This oversight has been fixed and now this will always throw an ERROR.
* This PR fixes this to instead use `action = "store"` which does allow you to pass an argument which will be coerced to a logical variable.
* We also adjusted an overly pedantic error message check to something that should work with both the previous and next versions of {optparse} -- note the next release of {optparse} will contain **classed** errors so in the future you could check instead that this throws an "optparse_bad_option_error" class error instead of checking the exact text of the error message.
* Note we do recommend using `action = "store_true"` and `action = "store_false"` instead of `action = "store"` for boolean flags but note these actions cannot take an argument e.g.

```
library("optparse")
parser <- OptionParser() |>
    add_option("--loud", "store_true", default = FALSE) |>
    add_option("--quiet", "store_false", dest = "loud")
```

and then you'd use `--loud` / `--quiet` instead of `--loud TRUE` / `--loud FALSE`...

